### PR TITLE
Fixed xdebug mode setting to enable development helpers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       WORDPRESS_DB_USER: ${DB_USER}
       WORDPRESS_DB_PASSWORD: ${DB_PASSWORD}
       WORDPRESS_DB_NAME: ${DB_NAME}
-      XDEBUG_MODE: debug
+      XDEBUG_MODE: develop,debug
       XDEBUG_CONFIG: "client_host=host.docker.internal"
     volumes:
       - ./:/var/www/html


### PR DESCRIPTION
According to XDebug documentation, `develop` mode should be useful. See https://xdebug.org/docs/all_settings#mode